### PR TITLE
export U8Array4, U8Array12, U8Array32 and U8Array64

### DIFF
--- a/lib/ldk_node.dart
+++ b/lib/ldk_node.dart
@@ -24,5 +24,6 @@ export './src/generated/api/types.dart'
         GossipSourceConfig,
         EntropySourceConfig_SeedFile;
 export 'src/root.dart';
+export 'src/generated/api/node.dart' show U8Array64, U8Array32;
 export 'src/utils/utils.dart'
     hide ExceptionBase, mapBuilderError, mapNodeBaseError, Frb;

--- a/lib/ldk_node.dart
+++ b/lib/ldk_node.dart
@@ -24,6 +24,7 @@ export './src/generated/api/types.dart'
         GossipSourceConfig,
         EntropySourceConfig_SeedFile;
 export 'src/root.dart';
-export 'src/generated/api/node.dart' show U8Array64, U8Array32;
+export 'src/generated/api/node.dart'
+    show U8Array4, U8Array12, U8Array64, U8Array32;
 export 'src/utils/utils.dart'
     hide ExceptionBase, mapBuilderError, mapNodeBaseError, Frb;


### PR DESCRIPTION
Since some functions or classes of the exported API require an `U8Array4`, `U8Array12`, `U8Array32` or `U8Array64` type as a parameter, it is needed to export them too. Otherwise it is not possible to pass a value to those parameters, the type will be wrong.

For example, to retrieve a payment, a `PaymentHash PaymentHash({required U8Array32 data})` has to be passed. The parameter named `data` only accepts an `U8Array32`. Without the `U8Array32` class being exported, it is impossible to create and pass a correct value of that type.

Instead of exporting the types, we could do the conversions to and from List<int>, Uint8List or a hex String in the package, so no special type has to be exported. What do you think about that and which type would be best?