### PR TITLE
add Builder with testnet and mutinynet default services

### DIFF
--- a/lib/src/root.dart
+++ b/lib/src/root.dart
@@ -1,5 +1,6 @@
 import 'package:ldk_node/src/generated/api/error.dart' as error;
 import 'package:ldk_node/src/generated/api/types.dart' as types;
+import 'package:ldk_node/src/utils/default_services.dart';
 import 'package:ldk_node/src/utils/utils.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -580,6 +581,24 @@ class Builder {
         defaultCltvExpiryDelta: 144,
         trustedPeers0Conf: [],
         probingLiquidityLimitMultiplier: 3));
+  }
+
+  /// Creates a new builder instance with default services configured for testnet.
+  ///
+  factory Builder.testnet() {
+    return Builder()
+        .setNetwork(types.Network.testnet)
+        .setEsploraServer(DefaultServicesTestnet.esploraServerUrl)
+        .setGossipSourceRgs(DefaultServicesTestnet.rgsServerUrl);
+  }
+
+  /// Creates a new builder instance with default services configured for mutinynet.
+  ///
+  factory Builder.mutinynet() {
+    return Builder()
+        .setNetwork(types.Network.signet)
+        .setEsploraServer(DefaultServicesMutinynet.esploraServerUrl)
+        .setGossipSourceRgs(DefaultServicesMutinynet.rgsServerUrl);
   }
 
   /// Configures the [Node] instance to source its wallet entropy from a seed file on disk.

--- a/lib/src/root.dart
+++ b/lib/src/root.dart
@@ -585,8 +585,11 @@ class Builder {
 
   /// Creates a new builder instance with default services configured for testnet.
   ///
-  factory Builder.testnet() {
-    return Builder()
+  factory Builder.testnet({types.Config? config}) {
+    final Builder builder =
+        config != null ? Builder.fromConfig(config: config) : Builder();
+
+    return builder
         .setNetwork(types.Network.testnet)
         .setEsploraServer(DefaultServicesTestnet.esploraServerUrl)
         .setGossipSourceRgs(DefaultServicesTestnet.rgsServerUrl);
@@ -594,8 +597,11 @@ class Builder {
 
   /// Creates a new builder instance with default services configured for mutinynet.
   ///
-  factory Builder.mutinynet() {
-    return Builder()
+  factory Builder.mutinynet({types.Config? config}) {
+    final Builder builder =
+        config != null ? Builder.fromConfig(config: config) : Builder();
+
+    return builder
         .setNetwork(types.Network.signet)
         .setEsploraServer(DefaultServicesMutinynet.esploraServerUrl)
         .setGossipSourceRgs(DefaultServicesMutinynet.rgsServerUrl);

--- a/lib/src/utils/default_services.dart
+++ b/lib/src/utils/default_services.dart
@@ -1,0 +1,9 @@
+class DefaultServicesTestnet {
+  static const String esploraServerUrl = 'https://testnet.ltbl.io/api';
+  static const String rgsServerUrl = 'https://testnet.ltbl.io/snapshot';
+}
+
+class DefaultServicesMutinynet {
+  static const String esploraServerUrl = 'https://mutinynet.ltbl.io/api';
+  static const String rgsServerUrl = 'https://mutinynet.ltbl.io/snapshot';
+}


### PR DESCRIPTION
This PR adds LtbLightning's Esplora and RGS server URL's for testnet and mutinynet through two Builder factory constructors: `Builder.testnet()` and `Builder.mutinynet()`.

Users can now just run
```
await Builder.testnet()
    .setEntropyBip39Mnemonic(mnemonic: ldk.Mnemonic(seedPhrase:"...",))
    .build();
```
or
```
await Builder.mutinynet()
    .setEntropyBip39Mnemonic(mnemonic: ldk.Mnemonic(seedPhrase:"...",))
    .build();
```
and will have a working node on the respective network, without having to configure their own Esplora or RGS server. The defaults can still be overwritten with the same functions or config parameter if desired.