### PR TITLE
export U8Array types to be able to form payment Id's etc.

### DIFF
--- a/lib/ldk_node.dart
+++ b/lib/ldk_node.dart
@@ -29,5 +29,6 @@ export './src/generated/api/types.dart'
         GossipSourceConfig,
         EntropySourceConfig_SeedFile;
 export 'src/root.dart';
+export 'src/generated/lib.dart' show U8Array4, U8Array12, U8Array64, U8Array32;
 export 'src/utils/utils.dart'
     hide ExceptionBase, mapLdkBuilderError, mapLdkNodeError, Frb;


### PR DESCRIPTION
This PR exposes the different U8Array types as used by LDK Node. They need to be exposed to an end user of the package, otherwise it is not possible to use some of the functions that expect an U8Array type as a parameter, for example to retrieve a specific payment. 